### PR TITLE
Fix WebVR mode

### DIFF
--- a/HelloWorld/app.js
+++ b/HelloWorld/app.js
@@ -435,9 +435,11 @@ function renderFrame() {
 
 // Resize the WebGL canvas when the window size changes
 function onWindowResize() {
-	camera.aspect = window.innerWidth / window.innerHeight;
-	camera.updateProjectionMatrix();
-	renderer.setSize(window.innerWidth, window.innerHeight);
+	if (!effect.isPresenting) {
+		camera.aspect = window.innerWidth / window.innerHeight;
+		camera.updateProjectionMatrix();
+		renderer.setSize(window.innerWidth, window.innerHeight);
+	}
 }
 
 let geocoder;


### PR DESCRIPTION
For some reasons, when switching to VR mode, the window got resized to size 200x113 (not sure why this size). Avoid resizing render canvas in WebVR mode.